### PR TITLE
Reqwest blocking feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,12 @@ description = "Calculate a projected fee for a channel open with LND UTXOs"
 
 [features]
 default = []
+blocking = []
 
 [dependencies]
 bitcoin = { version = "0.31.0", features = ["serde", "rand"] }
 rand = "0.8.5"
-reqwest = { version = "0.11.22", features = ["json"] }
+reqwest = { version = "0.11.22", features = ["blocking", "json"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 thiserror = "1.0.50"

--- a/README.md
+++ b/README.md
@@ -10,3 +10,21 @@ let projected_fees = calculate_fees(utxos, amount);
 
 let (total_fees, sat_vbyte) = projected_fees.fastest_fee;
 ```
+
+Festivus now supports both asynchronous and synchronous execution modes.
+
+By default, the calculate_fee function operates asynchronously. This is suitable for most applications that require non-blocking operations.
+
+If your application requires synchronous execution, you can enable the synchronous feature of festivus. To do this, add the following to your Cargo.toml:
+
+[dependencies]
+festivus = { git = "https://github.com/BlockSpaces/festivus", features = ["blocking"] }
+This enables the calculate_fee function to operate in a blocking manner.
+
+Testing:
+
+The festivus crate includes tests for both asynchronous and synchronous modes. You can run tests for the default asynchronous mode using:
+cargo test
+
+To run tests for the synchronous mode, use:
+cargo test --features "blocking"


### PR DESCRIPTION
Pull Request for Issue - [Allow library user to use the library synchronously](https://github.com/BlockSpaces/festivus/issues/1)
This pull request introduces the "blocking" feature to the festivus crate, allowing users to opt for synchronous execution of the calculate_fee function.

Changes Made:
- Implemented a synchronous version of the calculate_fee function, which can be activated using the "blocking" feature flag.
- Maintained the same function signature for both asynchronous and synchronous versions of calculate_fee. The appropriate version is determined by the feature flag:
- #[cfg(not(feature = "blocking"))] for the asynchronous (default) version.
- #[cfg(feature = "blocking")] for the synchronous version.
- Updated the reqwest dependency in Cargo.toml to include the "blocking" feature.
- Added new tests to ensure the functionality of the synchronous version of calculate_fee.
- Updated the README file to include instructions on how to use the new "blocking" feature.

Branching Strategy:
Branched off from the branch containing changes to the calculate_fee function signature in the other pull request I created to maintain consistency and avoid merge conflicts.